### PR TITLE
feat: add GCS directory tree tool with pagination support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# MCP-DB Development Guide
+
+## Commands
+- Build: `npm run build` or `make build`
+- Dev: `npm run dev` or `make dev` (with SSE transport)
+- Start: `npm run start`
+- Debug: `npm run debug` or `make debug`
+- Docker: `make init` (setup), `make down` (teardown)
+
+## Code Style
+- Use strict TypeScript with proper types from `types.ts`
+- Follow ESM imports (with .js extension in imports despite .ts files)
+- Organize imports: external libraries first, then internal modules
+- Use camelCase for functions/variables, PascalCase for interfaces
+- Handle errors with try/catch and use `formatErrorResponse` utility
+- Maintain modular organization (resources, tools, services)
+- Follow resource/command handler patterns established in codebase
+- Use Zod for config validation and type-safe error handling
+- Maintain clear separation of concerns between modules

--- a/README.md
+++ b/README.md
@@ -145,6 +145,21 @@ DATABASE_URL=postgres://user:password@localhost:5432/db npx github:dwarvesf/mcp-
 
 -   `duckdb_read_parquet_files`: Query Parquet files
 
+### GCS Tools
+
+-   `gcs_directory_tree`: Fetch the directory tree structure from a GCS bucket with pagination support (limit/offset)
+    ```json
+    {
+      "name": "gcs_directory_tree",
+      "arguments": {
+        "prefix": "data/",
+        "delimiter": "/",
+        "limit": 100,
+        "offset": 0
+      }
+    }
+    ```
+
 ## Development: Integrating a New Tool
 
 To integrate a new tool into the MCP server, follow these steps:

--- a/src/server.ts
+++ b/src/server.ts
@@ -128,7 +128,7 @@ export async function main(): Promise<void> {
     });
 
     // Register tool handlers
-    server.setRequestHandler(CallToolRequestSchema, createToolHandlers(pgPool, duckDBConn));
+    server.setRequestHandler(CallToolRequestSchema, createToolHandlers(pgPool, duckDBConn, gcs, config.gcsBucket));
     console.error(`Registered ${tools.length} tools`);
 
     // Register resource handlers

--- a/src/tools/gcs/directory-tree.ts
+++ b/src/tools/gcs/directory-tree.ts
@@ -1,0 +1,28 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const gcsDirectoryTreeTool: Tool = {
+  name: "gcs_directory_tree",
+  description: "Fetch the directory tree structure from GCS bucket with pagination support",
+  inputSchema: {
+    type: "object",
+    properties: {
+      prefix: {
+        type: "string",
+        description: "Optional prefix to filter objects by (e.g., 'folder/')",
+      },
+      delimiter: {
+        type: "string",
+        description: "Optional delimiter for hierarchical listing (e.g., '/')",
+        default: "/"
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of results to return (default: 1000)",
+      },
+      offset: {
+        type: "number",
+        description: "Number of results to skip for pagination (default: 0)",
+      }
+    }
+  }
+};

--- a/src/tools/gcs/handler.ts
+++ b/src/tools/gcs/handler.ts
@@ -1,0 +1,61 @@
+import { Storage } from '@google-cloud/storage';
+
+const DEFAULT_LIMIT = 1000;
+
+export interface GCSDirectoryTreeArgs {
+  prefix?: string;
+  delimiter?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function handleGCSDirectoryTree(
+  gcs: Storage,
+  bucket: string,
+  args: GCSDirectoryTreeArgs
+) {
+  if (!gcs) {
+    throw new Error("GCS not initialized");
+  }
+  if (!bucket) {
+    throw new Error("GCS bucket not configured. Use --gcs-bucket argument or GCS_BUCKET environment variable");
+  }
+
+  const prefix = args.prefix || '';
+  const delimiter = args.delimiter || '/';
+  const limit = args.limit || DEFAULT_LIMIT;
+  const offset = args.offset || 0;
+
+  // Get the GCS bucket
+  const gcsBucket = gcs.bucket(bucket);
+  
+  // Get files with options for pagination and hierarchy
+  const [files, , apiResponse] = await gcsBucket.getFiles({
+    prefix,
+    delimiter,
+    maxResults: limit,
+    pageToken: offset > 0 ? String(offset) : undefined,
+  });
+
+  // Extract prefixes (directories) from the API response
+  const directories = apiResponse.prefixes || [];
+
+  // Build the result structure
+  const result = {
+    files: files.map(file => ({
+      name: file.name,
+      size: parseInt(file.metadata.size, 10) || 0,
+      updated: file.metadata.updated,
+      contentType: file.metadata.contentType
+    })),
+    directories,
+    pagination: {
+      total: files.length + directories.length,
+      nextOffset: apiResponse.nextPageToken ? 
+        (offset + limit) : 
+        null
+    }
+  };
+
+  return result;
+}

--- a/src/tools/gcs/index.ts
+++ b/src/tools/gcs/index.ts
@@ -1,0 +1,1 @@
+export { gcsDirectoryTreeTool } from './directory-tree.js';

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,13 +1,16 @@
 import { sqlQueryCreateTool, sqlQueryReadTool, sqlQueryUpdateTool, sqlQueryDeleteTool } from './sql/index.js';
 import { duckDBReadTool } from './duckdb/index.js';
+import { gcsDirectoryTreeTool } from './gcs/index.js';
 
 export const tools = [
   sqlQueryCreateTool,
   sqlQueryReadTool,
   sqlQueryUpdateTool,
   sqlQueryDeleteTool,
-  duckDBReadTool
+  duckDBReadTool,
+  gcsDirectoryTreeTool
 ];
 
 export * from './sql/index.js';
-export * from './duckdb/index.js'; 
+export * from './duckdb/index.js';
+export * from './gcs/index.js'; 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,12 +9,20 @@ export interface DuckDBQueryArgs {
   query: string;
 }
 
+export interface GCSDirectoryTreeArgs {
+  prefix?: string;
+  delimiter?: string;
+  limit?: number;
+  offset?: number;
+}
+
 export interface ToolHandlers {
   sqlQueryCreate: (args: SQLQueryArgs) => Promise<QueryResult>;
   sqlQueryRead: (args: SQLQueryArgs) => Promise<QueryResult>;
   sqlQueryUpdate: (args: SQLQueryArgs) => Promise<QueryResult>;
   sqlQueryDelete: (args: SQLQueryArgs) => Promise<QueryResult>;
   duckDBReadParquetFiles: (args: DuckDBQueryArgs) => Promise<any>;
+  gcsDirectoryTree: (args: GCSDirectoryTreeArgs) => Promise<any>;
 }
 
 export interface ServerConfig {


### PR DESCRIPTION
## Summary
- Add a new `gcs_directory_tree` tool that provides a hierarchical view of GCS bucket contents with pagination support
- Handle large directory trees with limit/offset pagination
- Add filtering capabilities with prefix and delimiter options
- Return detailed file metadata and directory structure

## Implementation Details
- Created new GCS tools structure in `src/tools/gcs/`
- Added directory tree tool definition with clear schema for arguments
- Implemented handler with proper error handling and pagination
- Updated server.ts to pass GCS client to tool handlers
- Added new tool types to types.ts
- Updated documentation with examples in README.md
- Added CLAUDE.md with development guidelines

## Test plan
1. Configure GCS bucket and credentials
2. Run the server with `make dev` or `npm run dev`
3. Call the tool with various prefix/delimiter combinations
4. Test pagination by setting different limit/offset values
5. Verify the returned file metadata and directory structure

🤖 Generated with [Claude Code](https://claude.ai/code)