### PR TITLE
docs(readme): update server setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,16 +183,29 @@ make debug
 make dev
 ```
 
-or run with supergateway:
+This will start the server on port 3001 using SSE transport.
 
-```bash
-npx supergateway --port 8000 --stdio "make dev"
-```
+### Client Configuration
 
-then use ngrok to expose the server:
+To connect your MCP client to the local server, add the following configuration:
 
-```bash
-ngrok http 8000
+```json
+{
+  "mcpServers": {
+    "mcp-db": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "--net=host",
+        "supercorp/supergateway",
+        "--sse",
+        "http://localhost:3001/sse"
+      ]
+    }
+  }
+}
 ```
 
 ### Production Mode


### PR DESCRIPTION
## Changes

This PR improves the README documentation by simplifying the server setup instructions:

- Removed the ngrok method for exposing the server
- Added clear client configuration instructions for connecting to the local server
- Focused on the recommended `make dev` approach which starts the server on port 3001 using SSE transport
- Included JSON configuration example for MCP clients to connect directly to the local server

These changes make it easier for new users to get started with the MCP database server without requiring additional steps like setting up ngrok.