### PR TITLE
fix: serialize big int

### DIFF
--- a/src/fast-tools/duckdb/read.ts
+++ b/src/fast-tools/duckdb/read.ts
@@ -4,6 +4,7 @@ const duckdb = pkg;
 import { handleDuckDBQuery } from '../../tools/duckdb/handler.js';
 import { DuckDBQueryArgs } from '../../types.js';
 import { FastMCPTool } from '../types.js';
+import { serializeBigInt } from '../../utils.js';
 
 type DuckDBConnection = InstanceType<typeof duckdb.Connection>;
 
@@ -20,7 +21,7 @@ export function createDuckDBReadTool(duckDBConn: DuckDBConnection | null): FastM
         throw new Error("DuckDB connection not initialized");
       }
       const result = await handleDuckDBQuery(duckDBConn, args);
-      return JSON.stringify(result);
+      return JSON.stringify(serializeBigInt(result));
     }
   };
 } 


### PR DESCRIPTION
This pull request includes changes to the `src/fast-tools/duckdb/read.ts` file to enhance the handling of BigInt serialization in DuckDB query results.

Improvements to BigInt handling:

* [`src/fast-tools/duckdb/read.ts`](diffhunk://#diff-f54afe063658808456409c1ffda5854fef4046a27ef5e4de59ff319bb9e1dc2cR7): Imported the `serializeBigInt` utility function to handle BigInt serialization in DuckDB query results.
* [`src/fast-tools/duckdb/read.ts`](diffhunk://#diff-f54afe063658808456409c1ffda5854fef4046a27ef5e4de59ff319bb9e1dc2cL23-R24): Modified the `createDuckDBReadTool` function to use `serializeBigInt` when converting query results to JSON, ensuring proper serialization of BigInt values.