### PR TITLE
feat: add timeout option

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,8 @@ const ConfigSchema = z.object({
   gcsBucket: z.string().optional(),
   transport: z.enum(['stdio', 'sse']).default('stdio'),
   port: z.number().min(1).max(65535).default(3001),
-  host: z.string().default('localhost')
+  host: z.string().default('localhost'),
+  timeout: z.number().min(1000).default(300000) // Default timeout: 5 minutes (300000ms)
 });
 
 export function validateConfig(args: any) {
@@ -20,6 +21,7 @@ export function validateConfig(args: any) {
   const transport = args['--transport'] || process.env.TRANSPORT || 'stdio';
   const port = args['--port'] || parseInt(process.env.PORT || '3001', 10);
   const host = args['--host'] || process.env.HOST || 'localhost';
+  const timeout = args['--timeout'] || parseInt(process.env.TIMEOUT || '300000', 10);
 
   // Check if we're running in supergateway (it sets specific environment variables)
   const isInSupergateway = process.env.SUPERGATEWAY_PORT || process.env.SUPERGATEWAY_SSE_PATH;
@@ -44,7 +46,8 @@ export function validateConfig(args: any) {
       gcsBucket,
       transport,
       port,
-      host
+      host,
+      timeout
     });
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/src/fast-server.ts
+++ b/src/fast-server.ts
@@ -29,6 +29,7 @@ const args = arg({
   '--transport': String,
   '--port': Number,
   '--host': String,
+  '--timeout': Number,
 });
 
 // Enable colors by default
@@ -57,6 +58,7 @@ if (args['--help']) {
     --transport=TYPE      Transport type (stdio or sse) (default: stdio)
     --port=PORT           HTTP server port (default: 3001)
     --host=HOST           HTTP server host (default: localhost)
+    --timeout=TIMEOUT     Request timeout in milliseconds (default: 300000)
     -v, --version         Show version information
     -h, --help            Show this help message
 
@@ -65,6 +67,7 @@ if (args['--help']) {
     LOG_LEVEL             Logging level (default: info)
     GCP_SERVICE_ACCOUNT   Base64 encoded GCP service account key (optional)
     GCS_BUCKET            Default GCS bucket name (optional)
+    TIMEOUT               Request timeout in milliseconds (default: 300000)
 
   Example:
     export DATABASE_URL="postgresql://user:password@localhost:5432/mydb"
@@ -86,6 +89,7 @@ export async function main(): Promise<void> {
     const server = new FastMCP({
       name: "Data-Query-Server",
       version: "1.0.0",
+      timeout: config.timeout // Use the timeout from config
     });
 
     // Setup PostgreSQL
@@ -149,7 +153,8 @@ export async function main(): Promise<void> {
         transportType: "sse",
         sse: {
           endpoint: "/sse",
-          port: args['--port'] || 3001
+          port: args['--port'] || 3001,
+          timeout: config.timeout
         }
       });
       


### PR DESCRIPTION
This pull request introduces a new configuration option for setting request timeouts across various parts of the system. The changes ensure that the timeout value can be specified via configuration and command-line arguments, and is applied consistently in the server and transport layers.

Key changes include:

### Configuration Enhancements:
* Added a `timeout` field to the `ConfigSchema` in `src/config.ts` with a default value of 300000 milliseconds (5 minutes).
* Updated the `validateConfig` function in `src/config.ts` to handle the new `timeout` configuration. [[1]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R24) [[2]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L47-R50)

### Command-Line Interface (CLI) Updates:
* Included the `--timeout` argument in the CLI options in `src/fast-server.ts`.
* Updated the help message to document the new `--timeout` argument. [[1]](diffhunk://#diff-0f2628d5861757a7f7f19a5d44d8e71eab7244a0836c8fe2bdac8dae9f31360aR61) [[2]](diffhunk://#diff-0f2628d5861757a7f7f19a5d44d8e71eab7244a0836c8fe2bdac8dae9f31360aR70)

### Server Configuration:
* Applied the `timeout` configuration to the server initialization in `src/fast-server.ts`. [[1]](diffhunk://#diff-0f2628d5861757a7f7f19a5d44d8e71eab7244a0836c8fe2bdac8dae9f31360aR92) [[2]](diffhunk://#diff-0f2628d5861757a7f7f19a5d44d8e71eab7244a0836c8fe2bdac8dae9f31360aL152-R157)

### SSE Transport Updates:
* Added a `timeout` option to the `SSETransportOptions` interface in `src/transports/sse.ts`.
* Modified the `SSETransport` class to use the `timeout` option for setting request and response timeouts. [[1]](diffhunk://#diff-51f7df9c91bf9f0d1fcbd4313d34790287c73975821c6201331e3031b869617cL23-R25) [[2]](diffhunk://#diff-51f7df9c91bf9f0d1fcbd4313d34790287c73975821c6201331e3031b869617cR46-R51) [[3]](diffhunk://#diff-51f7df9c91bf9f0d1fcbd4313d34790287c73975821c6201331e3031b869617cR81-R86) [[4]](diffhunk://#diff-51f7df9c91bf9f0d1fcbd4313d34790287c73975821c6201331e3031b869617cR113-R117)